### PR TITLE
Запрос на исправление багов с уведомлениями

### DIFF
--- a/app/src/main/java/ru/commandos/diner/delivery/controller/OrderNotificationController.java
+++ b/app/src/main/java/ru/commandos/diner/delivery/controller/OrderNotificationController.java
@@ -42,7 +42,7 @@ public class OrderNotificationController {
                 new NotificationCompat.Builder(context, "DELIVERY_CHANNEL_ID")
                         .setSmallIcon(R.mipmap.ic_launcher)
                         .setContentTitle("У вас новый заказ!")
-                        .setContentText(order.getReadableFeatures() + " " + order.getReadableMass() + " кг")
+                        .setContentText(order.getReadableFeatures() + " " + order.getReadableMass())
                         .setContentIntent(resultPendingIntent);
         Notification notification = builder.build();
         notificationManager.notify(NOTIFICATION_ID, notification);

--- a/app/src/main/java/ru/commandos/diner/delivery/view/MainActivity.java
+++ b/app/src/main/java/ru/commandos/diner/delivery/view/MainActivity.java
@@ -59,11 +59,13 @@ public class MainActivity extends AppCompatActivity {
     private void onDenyClick(Unit unit) {
         ordersController.denyOrder();
         binding.cardView.showIncomingOrder(null);
+        orderNotificationController.deleteNotification();
     }
 
     private void onAcceptClick(Unit unit) {
         ordersController.acceptOrder();
         binding.recyclerView.getAdapter().notifyDataSetChanged();
         binding.cardView.showIncomingOrder(null);
+        orderNotificationController.deleteNotification();
     }
 }


### PR DESCRIPTION
Фикшены баги с уведомлениями

## Разрешаемые Карточки



## Подробная информация

 - В уведомлении вместо " *масса* кг кг" показывается " *масса* кг"
 - Теперь уведомление удаляется после нажатия на одну из кнопок (принять или отклонить)
